### PR TITLE
Minor bug fixes

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -16,7 +16,7 @@ RUN taskset -c 0 /root/steamcmd/steamcmd.sh \
             +quit
 RUN ln -s /root/steamcmd/linux32/libstdc++.so.6 /root/DST/bin/lib32/ && \
     cd /root/DST/bin && \
-    echo "taskset -c 0 /root/steamcmd/steamcmd.sh + login anonymous + force_install_dir /root/DST + app_update 343050 validate + quit" > start.sh && \
+    echo "/root/steamcmd/steamcmd.sh +@ShutdownOnFailedCommand 1 +@NoPromptForPassword 1 +login anonymous +force_install_dir /root/DST +app_update 343050 +quit" > start.sh && \
     echo "/root/DST/bin/dontstarve_dedicated_server_nullrenderer -only_update_server_mods" >> start.sh && \
     echo "/root/DST/bin/dontstarve_dedicated_server_nullrenderer -shard Master & /root/DST/bin/dontstarve_dedicated_server_nullrenderer -shard Caves" >> start.sh && \
     chmod +x start.sh

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -17,7 +17,7 @@ RUN taskset -c 0 /root/steamcmd/steamcmd.sh \
 RUN ln -s /root/steamcmd/linux32/libstdc++.so.6 /root/DST/bin/lib32/ && \
     cd /root/DST/bin && \
     echo "taskset -c 0 /root/steamcmd/steamcmd.sh + login anonymous + force_install_dir /root/DST + app_update 343050 validate + quit" > start.sh && \
-    echo "/root/DST/bin/dontstarve_dedicated_server_nullrenderer -only_update_server_mods" > start.sh && \
+    echo "/root/DST/bin/dontstarve_dedicated_server_nullrenderer -only_update_server_mods" >> start.sh && \
     echo "/root/DST/bin/dontstarve_dedicated_server_nullrenderer -shard Master & /root/DST/bin/dontstarve_dedicated_server_nullrenderer -shard Caves" >> start.sh && \
     chmod +x start.sh
 VOLUME /root/.klei/DoNotStarveTogether/Cluster_1

--- a/makedata.py
+++ b/makedata.py
@@ -8,8 +8,8 @@ service_format = '''
  {name}:
     image: thoxvi/dont-starve-together-docker-cluster:latest
     ports:
-      - "10999"
-      - "10998"
+      - "10999/udp"
+      - "10998/udp"
     volumes:
       - "{ini_path}:/root/.klei/DoNotStarveTogether/Cluster_1"
       - "{mods_setup_path}:/root/DST/mods/dedicated_server_mods_setup.lua"


### PR DESCRIPTION
1. `docker-compose.yml` 中的端口映射（`ports`）默认映射为 TCP，应改为 UDP
2. `Dockerfile` 中的管道操作符写错 （应为 `>>`），导致 `start.sh` 中没有更新游戏本体的命令
3. 原 `start.sh` 中的更新命令会卡死， 故使用了 https://www.v2ex.com/t/377339#r_4557838 中的更新命令

在修复 `Dockerfile` 后，别忘了更新 `thoxvi/dont-starve-together-docker-cluster` 镜像

另外特此感谢该项目提供的帮助！